### PR TITLE
Added missing sh extension to build-mutagen-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This project is configured to work with [https://mutagen.io/](https://mutagen.io
 
 ```sh
 cd yourprojectname/dockerfiles
-sh build-mutagen-config
+sh build-mutagen-config.sh
 sh start.sh
 ```
 


### PR DESCRIPTION
I added the .sh extension to the "sh build-mutagen-config" command which gave an error during installation